### PR TITLE
Get framework running again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
                     framework: '5.3.5',
                     boot     : '2.4.2'
             ],
-            selenium        : '4.1.0',
+            selenium        : '4.9.0',
             webdriverManager: '5.0.3'
     ]
 }

--- a/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
+++ b/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
@@ -6,7 +6,13 @@ import io.cucumber.java.en.When;
 import io.twagner.spiegel.cucumber.glue.SpringBootIntegrationTest;
 import io.twagner.spiegel.cucumber.glue.support.languages.en.Expectation;
 import io.twagner.spiegel.pageobjects.duckduckgo.DuckDuckGoHomePage;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
+
+import java.time.Duration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -51,7 +57,7 @@ public class DuckDuckGoHomePageSteps extends SpringBootIntegrationTest {
     public void theHomePageLinkShouldShouldNotDisplayOnTheDuckDuckGoHomePage(String shouldIt) throws Throwable {
         this.duckDuckGoHomePage = PageFactory.initElements(webDriver, DuckDuckGoHomePage.class);
         Expectation should = new Expectation(shouldIt);
-        assertThat(this.duckDuckGoHomePage.homePageLink.isDisplayed(), equalTo(should.it));
+        assertThat(this.duckDuckGoHomePage.homePageLogo.isDisplayed(), equalTo(should.it));
     }
 
     @Then("^the search query field (should|should not) display on the DuckDuckGo home page$")

--- a/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
+++ b/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
@@ -6,13 +6,7 @@ import io.cucumber.java.en.When;
 import io.twagner.spiegel.cucumber.glue.SpringBootIntegrationTest;
 import io.twagner.spiegel.cucumber.glue.support.languages.en.Expectation;
 import io.twagner.spiegel.pageobjects.duckduckgo.DuckDuckGoHomePage;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.Wait;
-
-import java.time.Duration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
+++ b/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoHomePageSteps.java
@@ -53,8 +53,8 @@ public class DuckDuckGoHomePageSteps extends SpringBootIntegrationTest {
         assertThat(webDriver.getTitle().equals(title), equalTo(should.it));
     }
 
-    @Then("^the home page link (should|should not) display on the DuckDuckGo home page$")
-    public void theHomePageLinkShouldShouldNotDisplayOnTheDuckDuckGoHomePage(String shouldIt) throws Throwable {
+    @Then("^the home page logo (should|should not) display on the DuckDuckGo home page$")
+    public void theHomePageLogoShouldShouldNotDisplayOnTheDuckDuckGoHomePage(String shouldIt) throws Throwable {
         this.duckDuckGoHomePage = PageFactory.initElements(webDriver, DuckDuckGoHomePage.class);
         Expectation should = new Expectation(shouldIt);
         assertThat(this.duckDuckGoHomePage.homePageLogo.isDisplayed(), equalTo(should.it));

--- a/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoSerpPageSteps.java
+++ b/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoSerpPageSteps.java
@@ -59,18 +59,4 @@ public class DuckDuckGoSerpPageSteps extends SpringBootIntegrationTest {
 
         assertThat(actualTitle, is(equalTo(specifiedTitle)));
     }
-
-    @Then("^the ([0-9]+(?:st|nd|rd|th)) search result on the DuckDuckGo search results page should show a link URL of (.*)")
-    public void theNthPositionResultOnTheDuckDuckGoSearchresultsPageShouldShouldNotShowALinkURLOfSpecifiedURL(
-            String position, String expectedUrl
-    ) throws Throwable {
-        this.serpPage = PageFactory.initElements(webDriver, DuckDuckGoSerpPage.class);
-
-        WebElement result = serpPage.getSearchResultByZeroIndex(
-                new OrdinalNumber(position).getZeroIndex()
-        );
-        String displayedUrl = result.findElement(By.xpath(".//div[contains(@class, 'result__extras__url')]/a")).getText();
-
-        assertThat(displayedUrl, is(equalTo(expectedUrl)));
-    }
 }

--- a/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoSerpPageSteps.java
+++ b/src/main/java/io/twagner/spiegel/cucumber/glue/duckduckgo/DuckDuckGoSerpPageSteps.java
@@ -22,7 +22,6 @@ public class DuckDuckGoSerpPageSteps extends SpringBootIntegrationTest {
         assertThat(serpPage.headerSearchButton.isDisplayed(), is(true));
         assertThat(serpPage.headerSearchField.isDisplayed(), is(true));
         assertThat(serpPage.headerSearchButton.isDisplayed(), is(true));
-//        assertThat(serpPage.resultNavigationLinks.length, is(greaterThan(0)));
     }
 
     @Then("^the header logo link (should|should not) display on the DuckDuckGo search results page$")

--- a/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoHomePage.java
+++ b/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoHomePage.java
@@ -4,13 +4,21 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.CacheLookup;
 import org.openqa.selenium.support.FindBy;
 
+/* For some reason right now when this page is loaded in Chromedriver,
+   different DOM elements (like for homePageLogo -- see below). than
+   what display within Chrome desktop.  For a demonstration framework
+   I have no problem working around this, but if if this was a test
+   framework used by a delivery team I expect that I might try
+   inquiring into the difference.
+ */
 public class DuckDuckGoHomePage {
     public static final String PAGE_URL = "https://duckduckgo.com/";
 
     private static final String XPATH_SEARCH_FORM = "//form[@id='searchbox_homepage']";
 
     @CacheLookup
-    @FindBy(xpath = "//div[contains(@class, 'header_logoStacked')]/img")
+    // xpath for Chrome desktop: "//div[contains(@class, 'header_logoStacked')]/img"
+    @FindBy(xpath = "//section[contains(@class, 'legacy-homepage_searchSection')]/img")
     public WebElement homePageLogo;
 
     @CacheLookup

--- a/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoHomePage.java
+++ b/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoHomePage.java
@@ -7,18 +7,18 @@ import org.openqa.selenium.support.FindBy;
 public class DuckDuckGoHomePage {
     public static final String PAGE_URL = "https://duckduckgo.com/";
 
-    private static final String XPATH_SEARCH_FORM = "//form[@id='search_form_homepage']";
+    private static final String XPATH_SEARCH_FORM = "//form[@id='searchbox_homepage']";
 
     @CacheLookup
-    @FindBy(xpath = "//a[@id='logo_homepage_link']")
-    public WebElement homePageLink;
+    @FindBy(xpath = "//div[contains(@class, 'header_logoStacked')]/img")
+    public WebElement homePageLogo;
 
     @CacheLookup
-    @FindBy(xpath = XPATH_SEARCH_FORM + "/input[@id='search_form_input_homepage']")
+    @FindBy(xpath = XPATH_SEARCH_FORM + "//input[@id='searchbox_input']")
     public WebElement searchField;
 
     @CacheLookup
-    @FindBy(xpath = XPATH_SEARCH_FORM + "/input[@id='search_button_homepage']")
+    @FindBy(xpath = XPATH_SEARCH_FORM + "//button[@type='submit']")
     public WebElement searchButton;
 
     public DuckDuckGoHomePage enterSearchString(String searchQuery) {

--- a/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoSerpPage.java
+++ b/src/main/java/io/twagner/spiegel/pageobjects/duckduckgo/DuckDuckGoSerpPage.java
@@ -39,6 +39,6 @@ public class DuckDuckGoSerpPage {
     public WebElement searchResultDiv;
 
     public WebElement getSearchResultByZeroIndex(int index) {
-        return searchResultDiv.findElement(By.xpath(".//div[@id = 'r1-" + index + "']"));
+        return searchResultDiv.findElement(By.xpath(".//article[@id = 'r1-" + index + "']"));
     }
 }

--- a/src/main/resources/features/duckduckgo/ddg_homepage.feature
+++ b/src/main/resources/features/duckduckgo/ddg_homepage.feature
@@ -6,8 +6,8 @@ Feature: Evaluate the DuckDuckGo Homepage
   Scenario: The home page displays the expected title
     Then the page title on the DuckDuckGo home page should display as DuckDuckGo — Privacy, simplified.
 
-  Scenario: The home page link displays on the DuckDuckGo Homepage
-    Then the home page link should display on the DuckDuckGo home page
+  Scenario: The home page logo displays on the DuckDuckGo Homepage
+    Then the home page lgoo should display on the DuckDuckGo home page
 
   Scenario: The search field displays on the DuckDuckGo Homepage
     Then the search query field should display on the DuckDuckGo home page

--- a/src/main/resources/features/duckduckgo/ddg_homepage.feature
+++ b/src/main/resources/features/duckduckgo/ddg_homepage.feature
@@ -7,7 +7,7 @@ Feature: Evaluate the DuckDuckGo Homepage
     Then the page title on the DuckDuckGo home page should display as DuckDuckGo — Privacy, simplified.
 
   Scenario: The home page logo displays on the DuckDuckGo Homepage
-    Then the home page lgoo should display on the DuckDuckGo home page
+    Then the home page logo should display on the DuckDuckGo home page
 
   Scenario: The search field displays on the DuckDuckGo Homepage
     Then the search query field should display on the DuckDuckGo home page

--- a/src/main/resources/features/duckduckgo/search_with_ddg.feature
+++ b/src/main/resources/features/duckduckgo/search_with_ddg.feature
@@ -18,5 +18,4 @@ Feature: Search with DuckDuckGo
     And the user enters a search query of duckduckgo to the search field on the DuckDuckGo home page
     And the user clicks the search button on the DuckDuckGo home page
     Then the 1st search result on the DuckDuckGo search results page should have a title of DuckDuckGo — Privacy, simplified.
-    And the 1st search result on the DuckDuckGo search results page should show a link URL of https://duckduckgo.com
     And the 2nd search result on the DuckDuckGo search results page should have a title of DuckDuckGo Privacy Browser - Apps on Google Play

--- a/src/main/resources/features/duckduckgo/search_with_ddg.feature
+++ b/src/main/resources/features/duckduckgo/search_with_ddg.feature
@@ -18,4 +18,4 @@ Feature: Search with DuckDuckGo
     And the user enters a search query of duckduckgo to the search field on the DuckDuckGo home page
     And the user clicks the search button on the DuckDuckGo home page
     Then the 1st search result on the DuckDuckGo search results page should have a title of DuckDuckGo — Privacy, simplified.
-    And the 2nd search result on the DuckDuckGo search results page should have a title of DuckDuckGo Privacy Browser - Apps on Google Play
+    And the 2nd search result on the DuckDuckGo search results page should have a title of DuckDuckGo at DuckDuckGo


### PR DESCRIPTION
This fixes drift that has developed between the framework, the tests, and the System under Test since the last time I worked on this actively.

All tests currently run green on local machine.